### PR TITLE
:lipstick: Simplify docker hub push.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ after_success:
     - docker images
     - |
         if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ; then
-            docker login -u="$DOCKER_HUB_LOGIN" -e="$DOCKER_HUB_EMAIL" -p="$DOCKER_HUB_PASSWORD" \
+            docker login -u="$DOCKER_HUB_LOGIN" -p="$DOCKER_HUB_PASSWORD" \
             && docker push rezzza/ci-docker-flow:$DOCKER_IMAGE_TAG
         fi
 


### PR DESCRIPTION
as --email flag is a deprecated feature since docker 1.12, will be
removed in docker 1.13.